### PR TITLE
edited docker-compose.yml for current docker version (18.09.6)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '2.3'
+version: "3.5"
 services:
   cdeep3m:
     image: cdeep3m
     build:
       dockerfile: Dockerfile
       context: .
-    runtime: nvidia
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
     command: /train/augdata /train/trainout --iter_size 1 --numiterations 10000 # runtraining.sh COMMAND 


### PR DESCRIPTION
edited docker-compose.yml for current docker version, tested with Docker version 18.09.6, build 481bc77156. now the runtime needs to be set in /etc/docker/daemon.json like this after installing nvidia-docker2:

```
{
    "runtimes": {
        "nvidia": {
            "path": "/usr/bin/nvidia-container-runtime",
            "runtimeArgs": []
        }
    },
    "default-runtime": "nvidia"
}
```
